### PR TITLE
Fixing concurrent reservations

### DIFF
--- a/src/test/java/com/ala/recruitment/reservations/RoomReservationTest.java
+++ b/src/test/java/com/ala/recruitment/reservations/RoomReservationTest.java
@@ -6,11 +6,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.IntStream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 public class RoomReservationTest {
@@ -93,4 +100,41 @@ public class RoomReservationTest {
         assertThat(sut.reservationsCount(user1)).isEqualTo(3);
     }
 
+    @Test
+    public void makesReservationsInMultithreadedEnvironment() throws InterruptedException {
+        int reservationsCount = 30;
+        int reservationLength = 2;
+        int usersCount = 5;
+        List<UUID> userIds = IntStream.rangeClosed(1, usersCount).mapToObj(__ -> UUID.randomUUID()).toList();
+
+        Collection<Callable<Void>> work = userIds.stream()
+                .map(id -> userReservationMaker(id, reservationsCount, reservationLength))
+                .collect(toList());
+        ExecutorService executorService = Executors.newFixedThreadPool(usersCount);
+        List<Future<Void>> results = executorService.invokeAll(work);
+        executorService.shutdown();
+
+        results.forEach(this::checkResult);
+        assertThat(sut.reservationsCount(userIds)).isEqualTo(reservationsCount);
+    }
+
+    Callable<Void> userReservationMaker(UUID userId, int reservationsCount, int reservationLength) {
+        return () -> {
+            IntStream.rangeClosed(1, reservationsCount).forEach((i) -> {
+                LocalDate from = firstDay.plusDays((i - 1) * reservationLength);
+                LocalDate until = firstDay.plusDays(i * reservationLength);
+                try {
+                    sut.makeReservation(new MakeReservationCommand(room1, userId, from, until));
+                    System.out.printf("thread=%s made reservation from=%s until=%s%n", Thread.currentThread().getName(), from, until);
+                } catch (RoomNotAvailableException roomNotAvailableException) {
+                    System.out.printf("thread=%s failed to reserve from=%s until=%s%n", Thread.currentThread().getName(), from, until);
+                }
+            });
+            return null;
+        };
+    }
+
+    private void checkResult(Future<Void> f) {
+        assertThatCode(f::get).doesNotThrowAnyException();
+    }
 }


### PR DESCRIPTION
Fixing concurrent reservations by performing pessimistic locking on Room entities.